### PR TITLE
fixes maps on CAP and in the news

### DIFF
--- a/app/assets/javascripts/map_regions.js
+++ b/app/assets/javascripts/map_regions.js
@@ -67,18 +67,17 @@ $(document).ready(function() {
   //   - CAP uses different path structure than the In the News section
   //   - In the News needs to provide "search_path" variable, since
   //     there are many different possible subjects (poets, events, works, etc)
-  $("svg path").click(function() {
+  $("#regions_map svg path").click(function() {
     var regionCode = getRegionCodeFromClass($(this).attr("class"));
     var regionName = getRegionTextFromCode(regionCode);
     var href = getRegionCodeFromText(regionName, "+");
 
     // in the news
     if (typeof search_path !== 'undefined') {
-      var fullurl = search_path + "?region=" + href;
+      var fullurl = search_path + "?f[]=spatial.region|" + href;
     // CAP
     } else {
-      var urlpiece = "../search?f[]=keywords|";
-      var fullurl = urlpiece + href;
+      var fullurl = "../search?f[]=keywords|"+href;
     }
     window.location = fullurl;  
   });

--- a/app/assets/stylesheets/map_regions.scss
+++ b/app/assets/stylesheets/map_regions.scss
@@ -18,14 +18,14 @@
 
 // Interactivity for Region Browse 
 
-.element_hover, .element_hover a {
+.element_hover, #regions_map .element_hover a {
   background-color: $brand-danger;
   color: white !important;
   cursor: pointer;
   text-decoration: underline;
 }
 
-.country_highlight {
+#regions_map .country_highlight {
   fill-opacity: 1;
   fill: $brand-danger !important;
   stroke-opacity: 1;
@@ -33,7 +33,7 @@
   stroke: white !important;
 }
 
-.svg_hover {
+#regions_map .svg_hover {
   cursor: pointer;
   fill: $brand-danger !important;
   stroke: white;

--- a/app/controllers/inthenewsnewsitems_controller.rb
+++ b/app/controllers/inthenewsnewsitems_controller.rb
@@ -4,7 +4,6 @@ class InthenewsnewsitemsController < ItemsController
     @title = "News"
     @facets = @items_api.query({
       "facet" => [
-        "topics", 
         "type"
       ]
     }).facets

--- a/app/views/contemporarypoets/items/browse_facet.html.erb
+++ b/app/views/contemporarypoets/items/browse_facet.html.erb
@@ -5,7 +5,6 @@
 <h1 class="sectiontitle"><%= t "contemporaryafricanpoets.title" %></h1>
 
 <h2><%= t "browse.browse_type", default: "Browse by" %> <%= @browse_facet_info["label"] %></h2>
-
 <%# deviation from orchid default: moving the tabs to a partial for
     inclusion from other templates %>
 <%= render "contemporarypoets/browse_tabs" %>

--- a/app/views/inthenewsnewsitems/home.html.erb
+++ b/app/views/inthenewsnewsitems/home.html.erb
@@ -16,10 +16,6 @@
         class: "display_callout display_callout_4" %>
       <%= link_to "Decade", inthenews_news_items_browse_facet_path(facet: "topics"), 
         class: "display_callout display_callout_1" %>
-      <%= link_to "Location", inthenews_news_items_browse_facet_path(facet: "places"), 
-        class: "display_callout display_callout_2" %>
-      <%= link_to "Region", inthenews_news_items_browse_facet_path(facet: "spatial.region"), 
-        class: "display_callout display_callout_3" %>
       <%= link_to "Tags", inthenews_news_items_browse_facet_path(facet: "keywords"), 
         class: "display_callout display_callout_4" %>
     </div>

--- a/app/views/layouts/body/_navbar_section.html.erb
+++ b/app/views/layouts/body/_navbar_section.html.erb
@@ -3,11 +3,11 @@
     <div class="navbar navbar-inverse">
       <div class="container navbar-container">  
         <ul class="nav navbar-nav">
-           <li class="<%= active?(/^#{config.relative_url_root}\/contemporarypoets\/browse/,
+           <li class="<%= active?(/^#{config.relative_url_root}\/contemporarypoets\/browse\/featured/,
             request.path) %>">
             <%= link_to "Featured", contemporarypoets_browse_facet_path(facet: "featured") %>
           </li>
-          <li class="<%= active?(/^#{config.relative_url_root}\/contemporarypoets\/browse/,
+          <li class="<%= active?(/^#{config.relative_url_root}\/contemporarypoets\/browse(?!\/featured)/,
             request.path) %>">
             <%= link_to t("browse.title", default: "Browse"), prefix_path("browse_path") %>
           </li>


### PR DESCRIPTION
removes some unused filters from news items page
CAP browse facet was not in the right location, moved file to get it to work
more specific css / js selectors so that we can disable on map view easily

closes https://github.com/CDRH/african_poetics/pull/100