### PR TITLE
switches poets to contributor, author from creator

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -19,7 +19,11 @@ class NewsItem < ApplicationRecord
   has_many :people, through: :news_item_roles
 
   def authors
-    news_item_roles.joins(:role).where(roles: { name: "Critic" })
+    people.where(news_item_roles: { author: true })
+  end
+
+  def author_roles
+    news_item_roles.where(author: true)
   end
 
   def citation
@@ -27,7 +31,7 @@ class NewsItem < ApplicationRecord
     # something displaying on many pages, here's a sample citation format
     cit = ""
 
-    a = authors.map { |role| role.person.name }.join("; ")
+    a = authors.map { |p| p.name }.join("; ")
     # formatting if there are authors
     if a.present?
       cit = "#{a}. "

--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -15,11 +15,11 @@ class Work < ApplicationRecord
   has_one :region, through: :location
 
   def authors
-    all_people = Person
-      .joins(work_roles: :role)
-      .where(work_roles: { work_id: id })
-      .where(roles: { name: ["Author", "Poet"]})
-      .distinct
+    people.where(work_roles: { author: true })
+  end
+
+  def author_roles
+    work_roles.where(author: true)
   end
 
   def es_id

--- a/app/views/inthenewsnewsitems/show.html.erb
+++ b/app/views/inthenewsnewsitems/show.html.erb
@@ -10,9 +10,9 @@
 <br>
 <%= @record.publication.name %>
 
-<h3>Authors (<%= @record.authors.count %>)</h3>
-<% if @record.authors.present? %>
-  <%= @record.authors.map { |r| r.name }.join("; ") %>
+<h3>Authors (<%= @record.author_roles.count %>)</h3>
+<% if @record.author_roles.present? %>
+  <%= @record.author_roles.map { |r| r.name }.join("; ") %>
 <% else %>
   No Author
 <% end %>

--- a/app/views/inthenewsworks/show.html.erb
+++ b/app/views/inthenewsworks/show.html.erb
@@ -24,7 +24,13 @@
 
 <% if @item.work_type.present? %>
   <div>
-    Type: <%= @item.work_type.name %>
+    Type: <%= @item.work_type.name.sub("|", ", ") %>
+  </div>
+<% end %>
+
+<% if @item.authors.present? %>
+  <div>
+    <%= "Author".pluralize(@item.authors.count) %>: <%= @item.authors.map { |a| a.name }.join("; ") %>
   </div>
 <% end %>
 

--- a/config/public.yml
+++ b/config/public.yml
@@ -18,7 +18,7 @@ default: &default
     media_server_dir: african_poetics
     # thumbnail size, ! means not to alter ratio, then max-width, max-height
     # IIIF size syntax reference: https://iiif.io/api/image/2.1/#size
-    thumbnail_size: !200,200
+    thumbnail_size: "!200,200"
 
     # REDIRECTS / REWRITES
 

--- a/config/sections/inthenews_news_items.yml
+++ b/config/sections/inthenews_news_items.yml
@@ -19,7 +19,7 @@ default: &default
 
   facets:
     en:
-      person.name:
+      contributor.name:
         label: African Poet
         flags:
           - search_filter


### PR DESCRIPTION
Thanks to adding a boolean "author?" field on work and news item roles, we can now safely say who is and who is not an author!

Yay!  Filters updated to use "contributors" as poets, "creators" as authors.
Still using the join table roles themselves in some cases so that we can list authors as "poet" / "critic" / etc

#142 