### PR TITLE
adds rescue block to make the Gale links valid URIs on the fly

### DIFF
--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -58,7 +58,8 @@ class NewsItem < ApplicationRecord
     end
 
     if source_link
-      cit += "<a href=\"#{source_link}\">#{source_link}</a>. "
+      best_link = sanitize_source_link
+      cit += "<a href=\"#{best_link}\">#{best_link}</a>. "
     end
 
     if source_access_date
@@ -74,6 +75,18 @@ class NewsItem < ApplicationRecord
   def name
     pub = publication ? publication.name : ""
     "'#{article_title}', #{pub} (#{year})"
+  end
+
+  private
+
+  def sanitize_source_link
+    # many of the Gale links have return characters / new lines / spaces in them
+    # which means they are not valid links, so attempt to patch that up here
+    URI.parse(source_link)
+    source_link
+  rescue => e
+    no_space = source_link.strip
+    no_space.gsub(/[\n\r]/, "")
   end
 
 end


### PR DESCRIPTION
several dozen of these links need to be addressed in the admin interface
but in case the situation recurs, this check should help

partially addresses: https://github.com/CDRH/african_poetics/issues/191
related to https://github.com/CDRH/african_poetics/issues/192