### PR TITLE
Remove link to old collections prototype

### DIFF
--- a/app/views/about/technicaldetails.html.erb
+++ b/app/views/about/technicaldetails.html.erb
@@ -16,8 +16,6 @@
 
 </ul>
 
-<p>Additional content in the <%= link_to "Collections Hub prototype", "https://cdrh.reclaim.hosting/omekas/s/apdp/" %>
-
 <h3>Data Management Plan</h3>
 
 <p>Research websites created by the Center for Digital Research in the Humanities are maintained by the UNL Libraries on servers purchased by the CDRH. Data is incrementally backed up on multiple redundant servers stored locally and off site in Omaha, Nebraska, housed and managed by the University of Nebraska Medical Center. The codebase and content files are developed in a networked environment and on a development server until ready for production, at which time they are transferred to a production server. Production server files are incrementally backed up regularly, and data and images are also stored on a redundant server. The CDRH is committed to maintaining previously created research sites over the long term. To this end, data is migrated to new servers every few years as needed, and care is taken not to change project URLs (or to add redirects if they must change). Sustainability is a priority for the Center, and it regularly undertakes projects that have potential for long-term development and thorough exploration of humanities issues.</p>


### PR DESCRIPTION
Removes stray link to an old prototype.